### PR TITLE
fix: Error bug missing `header-include.html`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Repo for wwwid.org website.",
   "main": "index.js",
   "scripts": {
+    "build": "npx gulp build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Ada error ketika kita coba menjalankan hugo langsung sehabis clone repo.

**Langkah repro:**
1. Clone repro
2. Langsung jalankan `gulp build`

**Error message:**
```
execute of template failed: template: _default/list.html:1:3: executing "_default/list.html" at <partial "header.html" .>
```

**Bonus:**
Saya juga menambahkan npm script `build` untuk developer yang tidak menginstall `gulp` secara global. Jalankan menggunakan `npm run build` / `yarn build`.