### PR TITLE
[style] remove margin from nested lists

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -344,6 +344,12 @@
   .post-content dl {
     margin-bottom: var(--content-gap);
   }
+  .post-content ul ul,
+  .post-content ol ol,
+  .post-content ul ol,
+  .post-content ol ul {
+    margin-bottom: 0;
+  }
   .post-content ul,
   .post-content ol {
     padding-left: 20px;


### PR DESCRIPTION
PR ini menghilangkan bottom margin di nested list.

Sebelum: (ada bottom margin di nested list yang membuat tampilan satu list terpisah-pisah)
![before](https://user-images.githubusercontent.com/6597211/82867672-760fb980-9f55-11ea-8ee4-928847e8aa3e.png)

Sesudah:
![after](https://user-images.githubusercontent.com/6597211/82867723-86279900-9f55-11ea-8c20-e3766bd6d657.png)
